### PR TITLE
Test: add provider contract coverage and phase notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,8 @@ This is Phase 1 of the ciagent implementation, providing the core CLI scaffold w
 - Codex-first chat integration via `IAssistantChat`
 - Comprehensive test suite (89.73% coverage)
 - Binary compilation for distribution
+
+### Incremental Phases
+
+- Phase 2 (complete): provider abstraction unification and shared streaming chunk contract.
+- Phase 3 (planned): provider reliability hardening (error normalization + contract enforcement).

--- a/packages/cli/tests/providers.contract.test.ts
+++ b/packages/cli/tests/providers.contract.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { mkdirSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import type { ChatChunk } from '../src/providers/types.js';
+
+const ALLOWED_CHUNK_TYPES = new Set<ChatChunk['type']>([
+  'assistant',
+  'result',
+  'system',
+  'tool',
+  'thinking',
+  'error',
+]);
+
+const testHome = '/tmp/cia-provider-contract-tests';
+const originalHome = process.env.HOME;
+
+function mockProviderSdks(): void {
+  mock.module('@openai/codex-sdk', () => ({
+    Codex: class {
+      startThread() {
+        return {
+          id: 'codex-session-123',
+          runStreamed: async () => ({
+            events: (async function* () {
+              yield { type: 'item.completed', item: { type: 'agent_message', text: 'hello' } };
+              yield { type: 'item.completed', item: { type: 'command_execution', command: 'ls' } };
+              yield { type: 'item.completed', item: { type: 'reasoning', text: 'thinking' } };
+              yield { type: 'turn.completed' };
+            })(),
+          }),
+        };
+      }
+
+      resumeThread(sessionId: string) {
+        return {
+          id: sessionId,
+          runStreamed: async () => ({ events: (async function* () {})() }),
+        };
+      }
+    },
+  }));
+
+  mock.module('@anthropic-ai/claude-agent-sdk', () => ({
+    query: () =>
+      (async function* () {
+        yield {
+          type: 'assistant',
+          message: {
+            content: [
+              { type: 'text', text: 'hello from claude' },
+              { type: 'tool_use', name: 'bash' },
+            ],
+          },
+        };
+        yield { type: 'result', session_id: 'claude-session-456' };
+      })(),
+  }));
+}
+
+async function collectChunks(generator: AsyncGenerator<ChatChunk>): Promise<ChatChunk[]> {
+  const chunks: ChatChunk[] = [];
+  for await (const chunk of generator) {
+    chunks.push(chunk);
+  }
+  return chunks;
+}
+
+describe('providers contract', () => {
+  beforeEach(() => {
+    rmSync(testHome, { recursive: true, force: true });
+    mkdirSync(join(testHome, '.codex'), { recursive: true });
+    writeFileSync(
+      join(testHome, '.codex', 'auth.json'),
+      JSON.stringify({
+        tokens: {
+          id_token: 'test-id-token',
+          access_token: 'test-access-token',
+        },
+      })
+    );
+    process.env.HOME = testHome;
+  });
+
+  afterEach(() => {
+    mock.restore();
+    rmSync(testHome, { recursive: true, force: true });
+    if (originalHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalHome;
+    }
+  });
+
+  it('factory returns supported providers and rejects unsupported', async () => {
+    mockProviderSdks();
+    const { createAssistantChat } = await import('../src/providers/index.js');
+
+    const codex = await createAssistantChat('codex');
+    const claude = await createAssistantChat('claude');
+
+    expect(codex.getType()).toBe('codex');
+    expect(claude.getType()).toBe('claude');
+    await expect(createAssistantChat('unsupported')).rejects.toThrow('Unsupported provider');
+  });
+
+  it('both providers emit only allowed chunk types and result carries sessionId', async () => {
+    mockProviderSdks();
+    const { createAssistantChat } = await import('../src/providers/index.js');
+
+    const codex = await createAssistantChat('codex');
+    const claude = await createAssistantChat('claude');
+
+    const codexChunks = await collectChunks(codex.sendQuery('prompt', '/tmp'));
+    const claudeChunks = await collectChunks(claude.sendQuery('prompt', '/tmp'));
+
+    for (const chunk of [...codexChunks, ...claudeChunks]) {
+      expect(ALLOWED_CHUNK_TYPES.has(chunk.type)).toBe(true);
+    }
+
+    const codexResult = codexChunks.find(chunk => chunk.type === 'result');
+    const claudeResult = claudeChunks.find(chunk => chunk.type === 'result');
+
+    expect(codexResult?.sessionId).toBeTruthy();
+    expect(claudeResult?.sessionId).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Problem
Provider integrations can drift over time, and without a shared contract test we risk regressions in chunk typing and session result handling across adapters. We also needed the README to reflect current incremental phase status so future contributors can orient quickly.

## Solution
Add a provider contract test that exercises both Codex and Claude adapters under mocked SDKs and asserts the shared `ChatChunk` contract boundaries. Keep the test focused on high-signal guarantees: supported provider factory behavior, allowed chunk types, and required `result.sessionId` output.

## Changes
- Added `packages/cli/tests/providers.contract.test.ts`
- Verified both providers emit only allowed `ChatChunk` types
- Verified both providers produce `result` chunks with session IDs
- Updated `README.md` with incremental phase status notes (Phase 2 complete, Phase 3 planned)

## Testing
- `bun run lint`
- `bun run type-check`
- `bun run test`
- Pre-push hook executed `make ci` successfully (includes lint, type-check, tests, build, and smoke checks)

## Example Output
```text
providers contract > factory returns supported providers and rejects unsupported
providers contract > both providers emit only allowed chunk types and result carries sessionId
```

## Notes
This keeps the suite lean by adding one contract-focused test file rather than duplicating provider behavior checks in multiple places.