### PR TITLE
Fix: scope Vitest discovery and CI test path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,9 +27,6 @@ lint: ## Run linting
 test: ## Run all tests
 	npm run test
 
-test-ci: ## Run tests in CI mode (no watch)
-	npx vitest --run
-
 test-coverage: ## Run tests with coverage report
 	npm run test:coverage
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,13 +1,17 @@
-import { defineConfig } from 'vitest/config';
+import { configDefaults, defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
+    include: ['packages/cli/tests/**/*.test.ts'],
+    exclude: [...configDefaults.exclude, 'dev/**'],
     testTimeout: 10000, // Increase timeout for reliability tests with retry delays
     coverage: {
       enabled: true,
       provider: 'v8',
+      include: ['packages/cli/src/**/*.ts'],
+      exclude: ['**/*.test.ts', '**/tests/**'],
       thresholds: {
         lines: 40,
         functions: 40,


### PR DESCRIPTION
## Problem
CI and hook validation were unstable because Vitest discovered tests and coverage targets outside the intended CLI scope, including repository areas unrelated to this package. This produced long runs, duplicate execution, and coverage threshold failures unrelated to shipped code.

## Solution
Scope test discovery and coverage to the CLI package under test, and keep one authoritative CI entrypoint through `make ci`. This keeps validation deterministic across local runs, hooks, and CI.

## Changes
- Removed the redundant `test-ci` target from `Makefile`
- Kept CI flow on `ci -> validate-all -> validate-l2/validate-l3`
- Updated `vitest.config.ts` to include only `packages/cli/tests/**/*.test.ts`
- Restored Vitest default excludes and appended `dev/**`
- Scoped coverage to `packages/cli/src/**/*.ts` and excluded test files

## Testing
- `make ci`
- Pre-push hook re-ran `make ci` successfully during `git push`

## Example Output
```text
Test Files  34 passed | 1 skipped (35)
Tests       483 passed | 9 skipped (492)
All CI checks passed!
```

## Notes
Some tests intentionally log expected error paths (e.g., mocked auth/config failures) and the suite currently emits `MaxListenersExceededWarning`; these are pre-existing and non-blocking for this change.