### PR TITLE
Fix: stabilize ci-full gated integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,3 +70,6 @@ install-hooks: ## Install Git pre-push hook
 
 ci: validate-all ## Run CI validation pipeline
 	@echo "$(BLUE)All CI checks passed!$(RESET)"
+
+ci-full: ## Run CI with gated E2E/integration tests enabled
+	RUN_E2E_TESTS=1 RUN_INTEGRATION_TESTS=1 $(MAKE) ci


### PR DESCRIPTION
## Problem
The new `ci-full` workflow needs to run all gated suites, but the MCP+Skills E2E integration tests were not worker-safe and depended on live provider/network behavior. This caused failures from `process.chdir()` in workers and intermittent timeouts tied to external model availability.

## Solution
Add a dedicated `ci-full` target and make the gated E2E integration suite deterministic. The tests now avoid worker-incompatible process mutation and use a mocked assistant provider so they validate orchestration/status behavior without relying on live Codex access.

## Changes
- Added `ci-full` target in `Makefile` to run `make ci` with `RUN_E2E_TESTS=1` and `RUN_INTEGRATION_TESTS=1`
- Updated `packages/cli/tests/e2e-mcp-skills.test.ts` to remove `process.chdir()` calls
- Introduced shared explicit test config injection (`baseTestConfig`) for MCP/skills setup
- Mocked `createAssistantChat` in the E2E MCP+Skills suite to remove external provider dependency
- Normalized MCP test config shape to `command` + `args`

## Testing
- `make ci-full`
- pre-push hook: `make ci` during `git push`

## Example Output
```text
make ci-full
...
Test Files  35 passed (35)
Tests       492 passed (492)
All CI checks passed!
```

## Notes
The suite still emits known non-blocking warnings from existing tests (e.g., `MaxListenersExceededWarning` and expected stderr logs for negative-path assertions), but the full pipeline now completes successfully.